### PR TITLE
Instance variables declaration bug

### DIFF
--- a/src/commander.cr
+++ b/src/commander.cr
@@ -5,6 +5,9 @@ module Commander
   alias Params = Array(String)
   alias Arguments = Array(String)
   alias Runner = Proc(Options, Arguments, Void)
+  alias OptionalRunner = Proc(Options, Arguments, Nil)
+  alias NoReturnRunner = Proc(Options, Arguments, NoReturn)
+  alias ArrayStringRunner = Proc(Options, Arguments, Array(String))
 
   def self.run(command : Command, params : Params)
     command.invoke(params)

--- a/src/commander/command.cr
+++ b/src/commander/command.cr
@@ -2,7 +2,7 @@ class Commander::Command
   property use : String
   property short : String
   property long : String
-  property runner : Runner
+  property runner : Runner | OptionalRunner | NoReturnRunner | ArrayStringRunner
 
   getter commands : Commands
   getter flags : Flags

--- a/src/commander/parser/base.cr
+++ b/src/commander/parser/base.cr
@@ -1,7 +1,7 @@
-module Commander::Parser::Base
+abstract class Commander::Parser::Base
   getter param : String
   getter next_param : String | Nil
-  getter skip_next : Proc
+  getter skip_next : Proc(Array(Int32))
   getter flags : Flags
   getter options : Options
 

--- a/src/commander/parser/long_flag_format.cr
+++ b/src/commander/parser/long_flag_format.cr
@@ -1,6 +1,6 @@
-class Commander::Parser::LongFlagFormat
-  include Base
+require "./base"
 
+class Commander::Parser::LongFlagFormat < Commander::Parser::Base
   PATTERN        = /^\-\-[a-zA-Z0-9-]{1,}=?/
   EQUALS_PATTERN = /^\-\-[a-zA-Z0-9-]{1,}=/
 

--- a/src/commander/parser/short_flag_format.cr
+++ b/src/commander/parser/short_flag_format.cr
@@ -1,6 +1,6 @@
-class Commander::Parser::ShortFlagFormat
-  include Base
+require "./base"
 
+class Commander::Parser::ShortFlagFormat < Commander::Parser::Base
   PATTERN = /^\-[a-zA-Z0-9]{1,}/
 
   protected def match?


### PR DESCRIPTION
### What's this PR do?

Spec is failed.

```
Error in macro 'getter' /usr/local/Cellar/crystal-lang/0.12.0/src/object.cr:221, line 3:

  1.     
  2.       
  3.         @param : String
  4.         
  5.       
  6. 
  7.       def param
  8.         @param
  9.       end
 10.     
 11.   

        @param : String
        ^~~~~~

can only declare instance variables of a non-generic class, not a module (Commander::Parser::Base)
```

I think, module can't declare instance variables of a non-generic class.
So I change the module to abstract class.

---

And then, another bug appears.

```
Error in ./spec/commander_spec.cr:12: instantiating 'Commander::Command:Class#new()'

          Commander::Command.new do |cmd|
                             ^~~

instantiating 'Commander::Command#initialize(Bool)'

in ./src/commander/command.cr:25: instantiating 'initialize(Bool)'

    initialize(help)
    ^~~~~~~~~~

in ./src/commander/command.cr:14: type must be (Options, Array(String) -> Void), not ((Options, Array(String) -> Void) | (Options, Array(String) -> Nil))

    @runner = Runner.new { |arguments, options| }
    ^

================================================================================

(Options, Array(String) -> Nil) trace:

  ./src/commander/command.cr:14

        @runner = Runner.new { |arguments, options| }
                         ^~~

  ./src/commander/command.cr:14

        @runner = Runner.new { |arguments, options| }
```

`Runner` type is `Proc(Options, Arguments, Void)`, but the actual result is `((Options, Array(String) -> Void) | (Options, Array(String) -> Nil))`. So I set some type aliases.
