### PR TITLE
(WORK IN PROGRESS) - Subcommand with parent flag

### DIFF
--- a/spec/commander_spec.cr
+++ b/spec/commander_spec.cr
@@ -346,7 +346,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.int["example"].should eq 0 as Int32
+            options.int["example"].should eq 0
             raise BlockRanException.new
           end
         end
@@ -366,7 +366,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.int["example"].should eq 9 as Int32
+            options.int["example"].should eq 9
             raise BlockRanException.new
           end
         end
@@ -386,7 +386,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.int["example"].should eq 9 as Int32
+            options.int["example"].should eq 9
             raise BlockRanException.new
           end
         end
@@ -406,7 +406,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.int["example"].should eq 9 as Int32
+            options.int["example"].should eq 9
             raise BlockRanException.new
           end
         end
@@ -472,7 +472,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.float["example"].should eq 1.1 as Float64
+            options.float["example"].should eq 1.1
             raise BlockRanException.new
           end
         end
@@ -492,7 +492,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.float["example"].should eq 1.9 as Float64
+            options.float["example"].should eq 1.9
             raise BlockRanException.new
           end
         end
@@ -512,7 +512,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.float["example"].should eq 1.9 as Float64
+            options.float["example"].should eq 1.9
             raise BlockRanException.new
           end
         end
@@ -532,7 +532,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.float["example"].should eq 1.9 as Float64
+            options.float["example"].should eq 1.9
             raise BlockRanException.new
           end
         end
@@ -552,7 +552,7 @@ describe Commander do
           end
 
           cmd.run do |options, _|
-            options.float["example"].should eq 19.0 as Float64
+            options.float["example"].should eq 19.0
             raise BlockRanException.new
           end
         end


### PR DESCRIPTION
Demonstrates bug reported in #7 when passing in a flag set on a parent command as well as a subcommand argument,  with a complaint that the subcommand flag does not exist. Created a PR to work through the issue and create visibility on the failure in travis.

`expected SubBlockRanException, got #<Commander::Parser::Exception: Flag '-b' does not exist>`
