### PR TITLE
Add support for global flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ cli = Commander::Command.new do |cmd|
     flag.long = "--env"
     flag.default = "development"
     flag.description = "The environment to run in."
+    flag.global = true
   end
 
   cmd.flags.add do |flag|
@@ -74,6 +75,8 @@ cli = Commander::Command.new do |cmd|
     cmd.short = "Kills server by pid."
     cmd.long = cmd.short
     cmd.run do |options, arguments|
+      options.int["pid"]    # => Int
+      options.string["env"] # => "development"
       arguments # => ["62719"]
     end
   end
@@ -134,6 +137,7 @@ end
   - Define defaults for each flag
   - Automatically validates, parses and casts to the correct type
   - Automatically passes all parsed `options` to `cmd.run`
+- Define global flags to pass to sub-commands
 - Receive additional cli arguments per command (`arguments` in `cmd.run`)
 - Automatically generates a help page for each command
   - Generates a `help` command for each command to access the help page

--- a/spec/commander_spec.cr
+++ b/spec/commander_spec.cr
@@ -564,6 +564,58 @@ describe Commander do
     end
   end
 
+  describe "global flag" do
+    it "passes flag to nested command" do
+      command = Commander::Command.new do |cmd|
+        cmd.flags.add do |flag|
+          flag.name = "example"
+          flag.short = "-e"
+          flag.default = ""
+          flag.description = "example description"
+          flag.global = true
+        end
+
+        cmd.commands.add do |cmd|
+          cmd.use = "execute"
+          cmd.short = "Execute a job"
+          cmd.long = cmd.short
+
+          cmd.flags.add do |flag|
+            flag.name = "job"
+            flag.short = "-j"
+            flag.default = 0
+            flag.description = "job id"
+          end
+
+          cmd.run do |options, arguments|
+            options.string["example"].should eq "crystal"
+            options.int["job"].should eq 1
+            raise BlockRanException.new
+          end
+
+          cmd.commands.add do |cmd|
+            cmd.use = "job"
+            cmd.short = "Execute a job"
+            cmd.long = cmd.short
+
+            cmd.run do |options|
+              options.string["example"].should eq "crystal"
+              raise BlockRanException.new
+            end
+          end
+        end
+      end
+
+      expect_raises(BlockRanException) do
+        command.invoke(["-e", "crystal", "execute", "-j", "1"])
+      end
+
+      expect_raises(BlockRanException) do
+        command.invoke(["-e", "crystal", "execute", "job"])
+      end
+    end
+  end
+
   describe "argument" do
     it "should extract arguments" do
       command = Commander::Command.new do |cmd|

--- a/src/commander/command.cr
+++ b/src/commander/command.cr
@@ -49,16 +49,7 @@ class Commander::Command
     EOS
   end
 
-  def invoke(params : Params, command : Command = self)
-    if param = params.shift?
-      if sub_command = find_command(param)
-        sub_command.invoke(params, sub_command)
-        return
-      end
-
-      params.unshift(param)
-    end
-
+  def invoke(params : Params, command : Command = self, extra_options = Options.new)
     parser = Parser.new(params, flags)
     options, arguments = parser.parse
 
@@ -67,7 +58,16 @@ class Commander::Command
       exit 0
     end
 
-    command.runner.call(options, arguments)
+    if argument = arguments.shift?
+      if sub_command = find_command(argument)
+        sub_command.invoke(arguments, sub_command, options.globals + extra_options)
+        return
+      end
+
+      arguments.unshift(argument)
+    end
+
+    command.runner.call(options + extra_options, arguments)
   end
 
   protected def name

--- a/src/commander/flag.cr
+++ b/src/commander/flag.cr
@@ -11,6 +11,7 @@ class Commander::Flag
   property long : String
   property default : Types
   property description : String
+  property global : Bool
 
   def initialize
     @name = ""
@@ -18,6 +19,7 @@ class Commander::Flag
     @long = ""
     @description = ""
     @default = nil
+    @global = false
   end
 
   def initialize

--- a/src/commander/option.cr
+++ b/src/commander/option.cr
@@ -1,0 +1,32 @@
+class Commander::Option(T)
+  getter value, flag
+
+  def initialize(@value : T, @flag : Flag); end
+
+  def key
+    flag.name
+  end
+
+  def global?
+    !!flag.global
+  end
+
+  def self.build(value, flag)
+    case value
+    when String
+      Option(String).new(value, flag)
+    when Int32
+      Option(Int32).new(value, flag)
+    when Int64
+      Option(Int64).new(value, flag)
+    when Float32
+      Option(Float32).new(value, flag)
+    when Float64
+      Option(Float64).new(value, flag)
+    when Bool
+      Option(Bool).new(value, flag)
+    else
+      Option(Nil).new(value, flag)
+    end
+  end
+end

--- a/src/commander/option_hash.cr
+++ b/src/commander/option_hash.cr
@@ -1,0 +1,10 @@
+class OptionHash(T1, T2) < Hash(T1, T2)
+  def [](key)
+    super.value
+  end
+
+  def delete(key)
+    result = super
+    result.value unless result.nil?
+  end
+end

--- a/src/commander/options.cr
+++ b/src/commander/options.cr
@@ -2,30 +2,70 @@ class Commander::Options
   getter string, int, float, bool, null
 
   def initialize
-    @string = Hash(String, String).new
-    @int = Hash(String, Int32 | Int64).new
-    @float = Hash(String, Float32 | Float64).new
-    @bool = Hash(String, Bool).new
-    @null = Hash(String, Nil).new
+    @string = OptionHash(String, Option(String)).new
+    @int = OptionHash(String, Option(Int32) | Option(Int64)).new
+    @float = OptionHash(String, Option(Float32) | Option(Float64)).new
+    @bool = OptionHash(String, Option(Bool)).new
+    @null = OptionHash(String, Option(Nil)).new
   end
 
-  def set(key, value : String)
-    string[key] = value
+  def set(key : String, option : Option(String))
+    string[key] = option
   end
 
-  def set(key, value : Int32 | Int64)
-    int[key] = value
+  def set(key : String, option : Option(Int32) | Option(Int64))
+    int[key] = option
   end
 
-  def set(key, value : Float32 | Float64)
-    float[key] = value
+  def set(key : String, option : Option(Float32) | Option(Float64))
+    float[key] = option
   end
 
-  def set(key, value : Bool)
-    bool[key] = value
+  def set(key : String, option : Option(Bool))
+    bool[key] = option
   end
 
-  def set(key, value : Nil)
-    null[key] = value
+  def set(key : String, option : Option(Nil))
+    null[key] = option
+  end
+
+  def globals
+    Options.new.tap do |options|
+      string.select { |_, v| v.global? }.each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      int.select { |_, v| v.global? }.each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      float.select { |_, v| v.global? }.each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      bool.select { |_, v| v.global? }.each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      null.select { |_, v| v.global? }.each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+    end
+  end
+
+  def +(other_options)
+    Options.new.tap do |options|
+      string.merge(other_options.string).each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      int.merge(other_options.int).each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      float.merge(other_options.float).each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      bool.merge(other_options.bool).each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+      null.merge(other_options.null).each_with_index do |(key, val)|
+        options.set(key, val)
+      end
+    end
   end
 end

--- a/src/commander/parser.cr
+++ b/src/commander/parser.cr
@@ -22,7 +22,10 @@ class Commander::Parser
   end
 
   private def set_defaults!
-    flags.each { |flag| options.set(flag.name, flag.default) }
+    flags.each do |flag|
+      option = Option.build(flag.default, flag)
+      options.set(option.key, option)
+    end
   end
 
   private def build

--- a/src/commander/parser/long_flag_format.cr
+++ b/src/commander/parser/long_flag_format.cr
@@ -32,21 +32,22 @@ class Commander::Parser::LongFlagFormat < Commander::Parser::Base
         doesnt_take_arguments!(flag.long)
       end
 
-      options.set(flag.name, flag.cast(value))
+      option = Option.build(flag.cast(value), flag)
+      options.set(option.key, option)
       return true
     end
-
-    no_such_flag!(key)
   end
 
   private def without_equals
     if flag = flags.find_long(param)
       if flag.type == Bool
-        options.set(flag.name, !flag.default)
+        option = Option.build(!flag.default, flag)
+        options.set(option.key, option)
         return true
       else
         if value = next_param
-          options.set(flag.name, flag.cast(value))
+          option = Option.build(flag.cast(value), flag)
+          options.set(option.key, option)
           skip_next.call
           return true
         else
@@ -55,6 +56,6 @@ class Commander::Parser::LongFlagFormat < Commander::Parser::Base
       end
     end
 
-    no_such_flag!(param)
+    false
   end
 end

--- a/src/commander/parser/short_flag_format.cr
+++ b/src/commander/parser/short_flag_format.cr
@@ -23,11 +23,13 @@ class Commander::Parser::ShortFlagFormat < Commander::Parser::Base
       flag_char = "-#{char}"
       if flag = flags.find_short(flag_char)
         if flag.type == Bool
-          options.set(flag.name, !flag.default)
+          option = Option.build(!flag.default, flag)
+          options.set(option.key, option)
           next
         else
           if value = next_param
-            options.set(flag.name, flag.cast(value))
+            option = Option.build(flag.cast(value), flag)
+            options.set(option.key, option)
             skip_next.call
             next
           else
@@ -36,7 +38,7 @@ class Commander::Parser::ShortFlagFormat < Commander::Parser::Base
         end
       end
 
-      no_such_flag!(flag_char)
+      return false
     end
 
     true


### PR DESCRIPTION
Hi @mrrooijen ,
Thank you for `commander`. It really helps with building nice interfaces for CLI applications.

I've just started learning Crystal and I would like to build small CLI app. I wanted to use `commander` for defining interface of my program but I've noticed there is no support for global flags. It makes sub-command execution a little bit strange: `s3 push -config ~/.config file.png` vs `s3 -config ~/.config push file.png`.

I've made PoC for adding global flags which are can be consumed by sub-commands. However there is one case which I don't know how to solve - raising exception if flag is not defined. It's caused by the fact that we don't know whether the flag is defined in sub-commands when we parse parent command's flags.

Since I'm new to Crystal I'm pushing my WIP for initial review and I'm looking forward to your feedback!