### PR TITLE
Support pass-through arguments

### DIFF
--- a/spec/commander_spec.cr
+++ b/spec/commander_spec.cr
@@ -44,6 +44,36 @@ describe Commander do
         end
       end
 
+      it "does not raise an exception if short flag doesn't exist and ignore_unmapped_flags is set" do
+        command = Commander::Command.new do |cmd|
+          cmd.ignore_unmapped_flags = true
+
+          cmd.run do |options, arguments|
+            arguments.should eq ["-f", "file.txt"]
+            raise BlockRanException.new
+          end
+        end
+
+        expect_raises(BlockRanException) do
+          command.invoke(["-f", "file.txt"])
+        end
+      end
+
+      it "does not raise an exception if long flag doesn't exist and ignore_unmapped_flags is set" do
+        command = Commander::Command.new do |cmd|
+          cmd.ignore_unmapped_flags = true
+
+          cmd.run do |options, arguments|
+            arguments.should eq ["--file", "file.txt"]
+            raise BlockRanException.new
+          end
+        end
+
+        expect_raises(BlockRanException) do
+          command.invoke(["--file", "file.txt"])
+        end
+      end
+
       it "raises an exception if long flag format is invalid" do
         message = "Long flag '-example-flag' is invalid. " +
           "Long flags must start with a '--', followed by a " +

--- a/spec/commander_spec.cr
+++ b/spec/commander_spec.cr
@@ -660,6 +660,30 @@ describe Commander do
     end
   end
 
+  describe "passthrough params" do
+    it "passes through any flags or arguments after -- " do
+      command = Commander::Command.new do |cmd|
+        cmd.flags.add do |flag|
+          flag.name = "example"
+          flag.short = "-e"
+          flag.long = "--example"
+          flag.default = "hello"
+          flag.description = "example description"
+        end
+
+        cmd.run do |options, arguments|
+          options.string["example"].should eq "world"
+          arguments.should eq ["--ignored-option", "some-value"]
+          raise BlockRanException.new
+        end
+      end
+
+      expect_raises(BlockRanException) do
+        command.invoke(["--example", "world", "--", "--ignored-option", "some-value"])
+      end
+    end
+  end
+
   describe "argument" do
     it "should extract arguments" do
       command = Commander::Command.new do |cmd|

--- a/src/commander/command.cr
+++ b/src/commander/command.cr
@@ -3,6 +3,7 @@ class Commander::Command
   property short : String
   property long : String
   property runner : Runner | OptionalRunner | NoReturnRunner | ArrayStringRunner
+  property? ignore_unmapped_flags : Bool
 
   getter commands : Commands
   getter flags : Flags
@@ -12,6 +13,7 @@ class Commander::Command
     @short = ""
     @long = ""
     @runner = Runner.new { |arguments, options| }
+    @ignore_unmapped_flags = false
     @commands = Commands.new(@flags)
 
     unless help?
@@ -58,7 +60,11 @@ class Commander::Command
       params.unshift(param)
     end
 
-    parser = Parser.new(params, flags)
+    parser = Parser.new(
+      params,
+      flags,
+      ignore_unmapped_flags: ignore_unmapped_flags?
+    )
     options, arguments = parser.parse
 
     if options.bool.delete("help")

--- a/src/commander/parser.cr
+++ b/src/commander/parser.cr
@@ -9,8 +9,9 @@ class Commander::Parser
   getter options : Options
   getter arguments : Arguments
   getter skip : Array(Int32)
+  getter? ignore_unmapped_flags : Bool
 
-  protected def initialize(@params : Params, @flags : Flags)
+  protected def initialize(@params : Params, @flags : Flags, @ignore_unmapped_flags = false)
     @options = Options.new
     @arguments = Arguments.new
     @skip = Array(Int32).new
@@ -46,6 +47,7 @@ class Commander::Parser
           skip_next,
           flags,
           options,
+          ignore_unmapped_flags: ignore_unmapped_flags?,
         )
 
         if fmt.match? && fmt.parse!

--- a/src/commander/parser.cr
+++ b/src/commander/parser.cr
@@ -29,6 +29,12 @@ class Commander::Parser
     params.each_with_index do |param, index|
       next if skip.includes?(index)
 
+      if param == "--"
+        rest_params = params[(index + 1)...(params.size)]
+        arguments.concat(rest_params)
+        break
+      end
+
       is_argument = true
       next_param = params[index + 1]?
       skip_next = ->{ skip << index + 1 }

--- a/src/commander/parser/base.cr
+++ b/src/commander/parser/base.cr
@@ -4,11 +4,13 @@ abstract class Commander::Parser::Base
   getter skip_next : Proc(Array(Int32))
   getter flags : Flags
   getter options : Options
+  getter? ignore_unmapped_flags : Bool
 
-  def initialize(@param, @next_param, @skip_next, @flags, @options)
+  def initialize(@param, @next_param, @skip_next, @flags, @options, @ignore_unmapped_flags = false)
   end
 
   private def no_such_flag!(flag)
+    return if ignore_unmapped_flags?
     raise Exception.new("Flag '#{flag}' does not exist")
   end
 

--- a/src/commander/parser/short_flag_format.cr
+++ b/src/commander/parser/short_flag_format.cr
@@ -19,9 +19,13 @@ class Commander::Parser::ShortFlagFormat < Commander::Parser::Base
       end
     end
 
+    found_flag_match = false
+
     chars.each do |char|
       flag_char = "-#{char}"
       if flag = flags.find_short(flag_char)
+        found_flag_match = true
+
         if flag.type == Bool
           options.set(flag.name, !flag.default)
           next
@@ -39,6 +43,6 @@ class Commander::Parser::ShortFlagFormat < Commander::Parser::Base
       no_such_flag!(flag_char)
     end
 
-    true
+    found_flag_match
   end
 end


### PR DESCRIPTION
This PR is a proposal to support two different methods of flag pass-through to support use cases for when a command might need to support arbitrary flags, e.g. commands that pass these flags on through to other command, of which there could be potentially many and no desire to keep up-to-date with a potentially ever-growing set of flag.

The first commit adds support for treating anything after a space-delimited `--` as arguments, similar to how Crystal's native `OptionParser` works. This supports a very explicit form of argument passthrough, e.g. `my-cli --some-flag -f file.txt -- --this-gets-passed-through`.

The second commit adds support for an opt-in approach of implicit pass-through, whereby any flags that are not mapped by the command would be treated as arguments. This doesn't change default behavior, but would allow a command to use this approach by specifying `cmd.ignore_unmapped_flags = true`. This could have the potential of being a little bit of a footgun, but is a good tool in cases where you're just wrapping another CLI tool, and want to provide a more compatible experience, that doesn't require putting a separating ` -- ` before any unmapped flags.