### PR TITLE
Add crystal requirement to shard.yml to enable install on Crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,6 @@
 name: commander
 version: 0.3.5
+crystal: '>= 0.34.0'
 
 authors:
   - Michael van Rooijen <michael@vanrooijen.io>


### PR DESCRIPTION
I chose `>= 0.34.0` kind of arbitrarily as "new enough", but let me know if this should be changed. But this is now required to be specified for Crystal 1.0.0 and the latest `shards`

I'm assuming this would also require a version bump.